### PR TITLE
feat : 추천 게시물 로직 변경

### DIFF
--- a/src/main/java/com/example/gotsaeng_back/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/gotsaeng_back/domain/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import com.example.gotsaeng_back.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.awt.print.Pageable;
@@ -18,5 +19,11 @@ public interface PostRepository extends JpaRepository<Post,Long> {
 
     List<Post> findPostsByUser(User user);
 
+    // 오늘 만든 게시물 중 좋아요, 조회수, 댓글 순으로 가중치를 줘서 점수가 제일 큰 거 순으로 정렬해서 모으기
+    @Query("SELECT p, COUNT(DISTINCT l) * 2 + COUNT(DISTINCT c) * 3 + p.viewCount " +
+            "FROM Post p LEFT JOIN p.likes l LEFT JOIN p.comments c " +
+            "WHERE p.createdDate >= CURRENT_DATE " +
+            "GROUP BY p")
+    List<Object[]> findPostsAndScores();
 
 }

--- a/src/main/java/com/example/gotsaeng_back/domain/post/service/PostService.java
+++ b/src/main/java/com/example/gotsaeng_back/domain/post/service/PostService.java
@@ -31,4 +31,5 @@ public interface PostService {
     Page<PostDetailDTO> getPosts(List<Post> posts, PageRequest pageRequest, String token);
 
     Page<PostDetailDTO> recommendPosts(String token, int page, int size);
+
 }


### PR DESCRIPTION
추천 게시물 로직을 자신의 팔로잉 사용자의 시청기록이 아닌 오늘 날짜에 만들어진 게시물들을 기준으로 
조회수, 좋아요, 댓글 순으로 가중치를 높게 줘서 추천.